### PR TITLE
fix(plex): adding /web as ingress root

### DIFF
--- a/cluster/apps/media/plex/helm-release.yaml
+++ b/cluster/apps/media/plex/helm-release.yaml
@@ -47,6 +47,7 @@ spec:
         ingressClassName: nginx
         annotations:
           cert-manager.io/cluster-issuer: letsencrypt-production
+          nginx.ingress.kubernetes.io/app-root: "/web"
           external-dns.alpha.kubernetes.io/target: "ipv4.${DOMAIN}"
           external-dns/is-public: 'true'
           hajimari.io/enable: 'true'


### PR DESCRIPTION
**Description of the change**

The plex ingress root is /web. In this PR I add an ingress-nginx annotation to do just that.

**Benefits**

No need to manually visit /web

**Possible drawbacks**

N/A

**Applicable issues**

N/A

**Additional information**

N/A
