### PR TITLE
feat(vaultwarden): Use mariadb for user storage

### DIFF
--- a/cluster/apps/home/vaultwarden/helm-release.yaml
+++ b/cluster/apps/home/vaultwarden/helm-release.yaml
@@ -86,3 +86,4 @@ spec:
       SMTP_EXPLICIT_TLS: "true"
       ADMIN_TOKEN: "${VAULTWARDEN_ADMIN_TOKEN}"
       SIGNUPS_ALLOWED: "false"
+      DATABASE_URL: mysql://root:${MARIADB_ROOT_PASSWORD}@mariadb.storage.svc.cluster.local:3306/vaultwarden


### PR DESCRIPTION
**Description of the change**

This PR is to enable vaultwarden to use the mariadb database for user storage.

**Benefits**

Having the passwords stored in the database gives more control of backup and restores

**Possible drawbacks**

security

**Applicable issues**

N/A

**Additional information**

If the cluster DNS domain ever changes this will break
