### PR TITLE
chore(charts): Updating helm repo interval to 5 minutes

### DIFF
--- a/cluster/charts/bitnami-charts.yaml
+++ b/cluster/charts/bitnami-charts.yaml
@@ -6,4 +6,4 @@ metadata:
   namespace: flux-system
 spec:
   url: https://charts.bitnami.com/bitnami
-  interval: 24h
+  interval: 5m

--- a/cluster/charts/dysnix-charts.yaml
+++ b/cluster/charts/dysnix-charts.yaml
@@ -5,5 +5,5 @@ metadata:
   name: dysnix
   namespace: flux-system
 spec:
-  interval: 1h
+  interval: 5m
   url: https://dysnix.github.io/charts

--- a/cluster/charts/external-dns-charts.yaml
+++ b/cluster/charts/external-dns-charts.yaml
@@ -5,5 +5,5 @@ metadata:
   name: external-dns
   namespace: flux-system
 spec:
-  interval: 1h
+  interval: 5m
   url: https://kubernetes-sigs.github.io/external-dns

--- a/cluster/charts/hajimari-charts.yaml
+++ b/cluster/charts/hajimari-charts.yaml
@@ -5,5 +5,5 @@ metadata:
   name: hajimari
   namespace: flux-system
 spec:
-  interval: 1h
+  interval: 5m
   url: https://hajimari.io

--- a/cluster/charts/ingress-nginx-charts.yaml
+++ b/cluster/charts/ingress-nginx-charts.yaml
@@ -6,4 +6,4 @@ metadata:
   namespace: flux-system
 spec:
   url: https://kubernetes.github.io/ingress-nginx
-  interval: 24h
+  interval: 5m

--- a/cluster/charts/jetstack-charts.yaml
+++ b/cluster/charts/jetstack-charts.yaml
@@ -6,4 +6,4 @@ metadata:
   namespace: flux-system
 spec:
   url: https://charts.jetstack.io
-  interval: 24h
+  interval: 5m

--- a/cluster/charts/k8s-at-home-charts.yaml
+++ b/cluster/charts/k8s-at-home-charts.yaml
@@ -6,4 +6,4 @@ metadata:
   namespace: flux-system
 spec:
   url: https://k8s-at-home.com/charts/
-  interval: 24h
+  interval: 5m

--- a/cluster/charts/k8s-gateway-charts.yaml
+++ b/cluster/charts/k8s-gateway-charts.yaml
@@ -5,5 +5,5 @@ metadata:
   name: k8s-gateway
   namespace: flux-system
 spec:
-  interval: 1h
+  interval: 5m
   url: https://ori-edge.github.io/k8s_gateway/

--- a/cluster/charts/kubereboot-charts.yaml
+++ b/cluster/charts/kubereboot-charts.yaml
@@ -5,5 +5,5 @@ metadata:
   name: kubereboot
   namespace: flux-system
 spec:
-  interval: 1h
+  interval: 5m
   url: https://kubereboot.github.io/charts

--- a/cluster/charts/metrics-server-charts.yaml
+++ b/cluster/charts/metrics-server-charts.yaml
@@ -5,5 +5,5 @@ metadata:
   name: metrics-server
   namespace: flux-system
 spec:
-  interval: 1h
+  interval: 5m
   url: https://kubernetes-sigs.github.io/metrics-server

--- a/cluster/charts/nfs-subdir-external-provisioner-charts.yaml
+++ b/cluster/charts/nfs-subdir-external-provisioner-charts.yaml
@@ -7,4 +7,4 @@ metadata:
   namespace: flux-system
 spec:
   url: https://kubernetes-sigs.github.io/nfs-subdir-external-provisioner/
-  interval: 24h
+  interval: 5m

--- a/cluster/charts/prometheus-community-charts.yaml
+++ b/cluster/charts/prometheus-community-charts.yaml
@@ -6,4 +6,4 @@ metadata:
   namespace: flux-system
 spec:
   url: https://prometheus-community.github.io/helm-charts/
-  interval: 24h
+  interval: 5m

--- a/cluster/charts/rickcoxdev-arm-charts.yaml
+++ b/cluster/charts/rickcoxdev-arm-charts.yaml
@@ -6,4 +6,4 @@ metadata:
   namespace: flux-system
 spec:
   url: https://rickcoxdev.github.io/arm-charts/
-  interval: 24h
+  interval: 5m

--- a/cluster/charts/stakater-charts.yaml
+++ b/cluster/charts/stakater-charts.yaml
@@ -5,5 +5,5 @@ metadata:
   name: stakater
   namespace: flux-system
 spec:
-  interval: 1h
+  interval: 5m
   url: https://stakater.github.io/stakater-charts


### PR DESCRIPTION
**Description of the change**

Sometimes when merging in helm chart updates from renovate the helm repo in the cluster doesn't yet have the new version. So I'm updating the inverval of reconciling of the helm repos to 5 minutes.

**Benefits**

Avoiding errors when updating helm charts

**Possible drawbacks**

Increased network traffic to update helm repos often.

**Applicable issues**

N/A

**Additional information**

N/A
